### PR TITLE
Expose PlayerInputs component

### DIFF
--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -69,7 +69,7 @@ public class Player : MonoBehaviour
     private bool isFlashing = false;
     private CharacterEquipment characterEquipment;
     private PlayerAnimatorBridge _animBridge;
-    private Input_Control _input;
+    [SerializeField] private PlayerInputs _inputs;
         private float baseMoveSpeed;
         private int baseMaxHealth;
         private float reflectFlatCurrent = 0f;
@@ -198,21 +198,17 @@ public class Player : MonoBehaviour
     
     void OnEnable()
     {
-        if (_input == null)
+        if (_inputs != null)
         {
-            _input = new Input_Control();
+            _inputs.Dash.performed += OnDashAction;
         }
-        _input.Enable();
-        // Dash via new input system
-        _input.Gameplay.Dash.performed += OnDashAction;
     }
 
     void OnDisable()
     {
-        if (_input != null)
+        if (_inputs != null)
         {
-            _input.Gameplay.Dash.performed -= OnDashAction;
-            _input.Disable();
+            _inputs.Dash.performed -= OnDashAction;
         }
     }
 
@@ -292,7 +288,7 @@ public class Player : MonoBehaviour
 
     Vector3 GetMoveVector()
     {
-        Vector2 move = _input != null ? _input.Gameplay.Move.ReadValue<Vector2>() : Vector2.zero;
+        Vector2 move = _inputs != null ? _inputs.Move.ReadValue<Vector2>() : Vector2.zero;
         Vector3 v = new Vector3(move.x, 0f, move.y);
         if (v.sqrMagnitude > 1f) v.Normalize();
         return v;

--- a/Assets/Scripts/Player/PlayerInputs.cs
+++ b/Assets/Scripts/Player/PlayerInputs.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[DefaultExecutionOrder(-210)]
+public class PlayerInputs : MonoBehaviour
+{
+    [Header("Gameplay")]
+    public InputAction Move;
+    public InputAction Dash;
+
+    private void OnEnable()
+    {
+        if (Move == null)
+        {
+            Move = new InputAction("Move", InputActionType.Value);
+            Move.AddCompositeBinding("2DVector")
+                .With("Up", "<Keyboard>/w")
+                .With("Down", "<Keyboard>/s")
+                .With("Left", "<Keyboard>/a")
+                .With("Right", "<Keyboard>/d");
+        }
+        if (Dash == null)
+        {
+            Dash = new InputAction("Dash", InputActionType.Button, "<Keyboard>/space");
+        }
+        Move.Enable();
+        Dash.Enable();
+    }
+
+    private void OnDisable()
+    {
+        Move.Disable();
+        Dash.Disable();
+    }
+}

--- a/Assets/Scripts/Player/PlayerInputs.cs.meta
+++ b/Assets/Scripts/Player/PlayerInputs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 223b810f-7524-4704-b3e1-a316c734759b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Introduce `PlayerInputs` component exposing `Move` and `Dash` input actions
- Swap `Player` to use `PlayerInputs` so actions can be assigned via inspector

## Testing
- `dotnet test` *(command not found)*
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c624702483208cdc0cd97f3e9079