### PR TITLE
Support legacy input when new Input System absent

### DIFF
--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -1,7 +1,9 @@
 using UnityEngine;
 using UnityEngine.Events;
 using System.Collections.Generic;
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
+#endif
 
 [DefaultExecutionOrder(-200)]
 /// <summary>
@@ -69,7 +71,9 @@ public class Player : MonoBehaviour
     private bool isFlashing = false;
     private CharacterEquipment characterEquipment;
     private PlayerAnimatorBridge _animBridge;
+#if ENABLE_INPUT_SYSTEM
     [SerializeField] private PlayerInputs _inputs;
+#endif
         private float baseMoveSpeed;
         private int baseMaxHealth;
         private float reflectFlatCurrent = 0f;
@@ -196,6 +200,7 @@ public class Player : MonoBehaviour
         Debug.Log($"StartingClass: {startingClass}");
     }
     
+    #if ENABLE_INPUT_SYSTEM
     void OnEnable()
     {
         if (_inputs != null)
@@ -213,6 +218,12 @@ public class Player : MonoBehaviour
     }
 
     void OnDashAction(InputAction.CallbackContext _)
+    {
+        TryDash();
+    }
+    #endif
+
+    void TryDash()
     {
         if (isDashing || currentDashCharges <= 0) return;
         Vector3 dir = GetMoveVector();
@@ -232,6 +243,12 @@ public class Player : MonoBehaviour
         }
         UpdateDashCharges();
         UpdateDamageCooldowns();
+#if !ENABLE_INPUT_SYSTEM
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            TryDash();
+        }
+#endif
     }
     
     #region MOVEMENT
@@ -283,12 +300,16 @@ public class Player : MonoBehaviour
             }
         }
         
-        // Dash is handled via input actions (OnDashAction)
+        // Dash input is handled separately via TryDash
     }
 
     Vector3 GetMoveVector()
     {
+#if ENABLE_INPUT_SYSTEM
         Vector2 move = _inputs != null ? _inputs.Move.ReadValue<Vector2>() : Vector2.zero;
+#else
+        Vector2 move = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
+#endif
         Vector3 v = new Vector3(move.x, 0f, move.y);
         if (v.sqrMagnitude > 1f) v.Normalize();
         return v;

--- a/Assets/Scripts/Player/PlayerInputs.cs
+++ b/Assets/Scripts/Player/PlayerInputs.cs
@@ -1,3 +1,5 @@
+// Only compile full helper when the new Input System package is available.
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -33,3 +35,9 @@ public class PlayerInputs : MonoBehaviour
         Dash.Disable();
     }
 }
+#else
+using UnityEngine;
+
+// Minimal stub so projects without the new Input System still compile
+public class PlayerInputs : MonoBehaviour { }
+#endif // ENABLE_INPUT_SYSTEM


### PR DESCRIPTION
## Summary
- guard PlayerInputs helper and Player references with ENABLE_INPUT_SYSTEM
- provide old Input-based movement & dash fallback
- add stub PlayerInputs class when new Input System package isn't present

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update && apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*
- `mcs Assets/Scripts/Player/Player.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cbd7a62083208ed568c04fb44323