### PR TITLE
Handle missing UIToggleHotkey panels

### DIFF
--- a/Assets/Scripts/Player/PlayerInputs.cs.meta
+++ b/Assets/Scripts/Player/PlayerInputs.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 223b810f-7524-4704-b3e1-a316c734759b
+guid: 223b810f75244704b3e1a316c734759b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/UI/UIToggleHotkey.cs
+++ b/Assets/Scripts/UI/UIToggleHotkey.cs
@@ -25,6 +25,14 @@ public class UIToggleHotkey : MonoBehaviour
     [Header("Optional Save Button")]
     [Tooltip("If true, when toggling this panel ON, will show a Save button if a SavePanelHook is present")] public bool enableSaveButton = false;
 
+    void Awake()
+    {
+        if (panels == null || panels.Length == 0)
+        {
+            panels = new GameObject[] { gameObject };
+        }
+    }
+
     void OnEnable()
     {
         if (toggleAction != null)
@@ -97,7 +105,7 @@ public class UIToggleHotkey : MonoBehaviour
     public void Toggle()
     {
         if (panels == null || panels.Length == 0) return;
-        bool target = !panels[0].activeSelf;
+        bool target = !AnyPanelActive();
         SetActive(target);
     }
 


### PR DESCRIPTION
## Summary
- fix PlayerInputs.cs.meta GUID format so Unity recognizes the script and PlayerInputs class is compiled
- default UIToggleHotkey panels to its own GameObject and derive target state from any active panels to avoid unassigned references

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9068aa2a08320b0911f838e59b332